### PR TITLE
fix: update template pjson - add private & publishConfig settings

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -1,4 +1,5 @@
 {
+  "private": [private],
   "version": "0.0.0-development",
   "name": "@telus/[name]",
   "description": "[description]",
@@ -10,6 +11,9 @@
   "license": "[license]",
   "main": "index.js",
   "keywords": [keywords],
+  "publishConfig": {
+    "access": "[access]"
+  },
   "engines": {
     "node": ">=8"
   },


### PR DESCRIPTION
Hey @ahmadnassri, I noticed these settings were missing from the template `package.json`. I updated them so they get populated based on the answers (if it's an OSS package or not). Hope it's fine, pls have a look!