### PR TITLE
chore: fix unit step inside template CI config

### DIFF
--- a/template/circle.yml
+++ b/template/circle.yml
@@ -48,7 +48,7 @@ jobs:
     executor: app
     steps:
       - attach
-      - run: npm run unit
+      - run: npm run test
 
   release:
     executor: app


### PR DESCRIPTION
As I was updating `@telus/isomorphic-core` to get it aligned with the template here, I noticed we have a small bug in the unit step (the script for running unit tests is called `test`, not `unit`). Small fix 😄 