### PR TITLE
Add step in CI to add github to known hosts

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,14 @@ executors:
       - image: telus/build-essential
 
 commands:
+  ssh:
+    steps:
+      - add_ssh_keys
+      - run:
+          name: Add github.com to known hosts
+          command: |
+            mkdir ~/.ssh
+            ssh-keyscan -H github.com >> ~/.ssh/known_hosts
   persist:
     steps:
       - persist_to_workspace: { root: ~/src, paths: . }
@@ -40,6 +48,7 @@ jobs:
     executor: app
     steps:
       - attach
+      - ssh
       - run: npx semantic-release
 
 workflows:

--- a/circle.yml
+++ b/circle.yml
@@ -34,6 +34,7 @@ jobs:
   build:
     executor: app
     steps:
+      - ssh
       - checkout
       - install
       - persist

--- a/template/circle.yml
+++ b/template/circle.yml
@@ -8,6 +8,14 @@ executors:
       - image: telus/build-essential
 
 commands:
+  ssh:
+    steps:
+      - add_ssh_keys
+      - run:
+          name: Add github.com to known hosts
+          command: |
+            mkdir ~/.ssh
+            ssh-keyscan -H github.com >> ~/.ssh/known_hosts
   persist:
     steps:
       - persist_to_workspace: { root: ~/src, paths: . }
@@ -54,6 +62,7 @@ jobs:
     executor: app
     steps:
       - attach
+      - ssh
       - npmrc
       - run: npx semantic-release
 

--- a/template/circle.yml
+++ b/template/circle.yml
@@ -42,6 +42,7 @@ jobs:
   build:
     executor: app
     steps:
+      - ssh
       - checkout
       - install
       - persist


### PR DESCRIPTION
Ensures github.com is added to known hosts so that the release step runs as expected.
See https://discuss.circleci.com/t/known-hosts-in-circle-2-0/18544/2.