### PR TITLE
feat(ci): improve lint job output & run all linting even on error

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint:ec": "npx editorconfig-checker .",
     "lint:js": "npx eslint .",
     "lint:md": "npx remark --quiet --frail .",
-    "lint": "npx npm-run-all -p lint:*"
+    "lint": "npx npm-run-all -p -c -l lint:*"
   },
   "dependencies": {
     "fast-glob": "^2.2.4",

--- a/template/package.json
+++ b/template/package.json
@@ -27,7 +27,7 @@
     "lint:ec": "npx editorconfig-checker .",
     "lint:js": "npx eslint .",
     "lint:md": "npx remark --quiet --frail .",
-    "lint": "npx npm-run-all -p lint:*",
+    "lint": "npx npm-run-all -p -c -l lint:*",
     "setup-local": "npx install-group peer --package @telus/build-essential --no-save",
     "fix:js": "npm run lint:js -- --fix",
     "fix:md": "npm run lint:md -- -o",


### PR DESCRIPTION
`-c` will continue if one of the linters fails, and `-l` adds the label for the job in the output (given it runs them in parallel and it gets confusing)