### PR TITLE
docs: deprecate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![maintenance-status](https://img.shields.io/badge/maintenance-passively--maintained-yellowgreen.svg)
+![maintenance-status](https://img.shields.io/badge/maintenance-deprecated-red.svg)
 ![npm (scoped)](https://img.shields.io/npm/v/@telus/create-library)
 
 


### PR DESCRIPTION
This starter kit is old and poorly maintained, a more recent version is being developed: https://github.com/telus/dx-packages-starter-kit